### PR TITLE
store path separately from base url, overriding resource URL inference

### DIFF
--- a/lib/json_api_client/request.ex
+++ b/lib/json_api_client/request.ex
@@ -66,11 +66,13 @@ defmodule JsonApiClient.Request do
 
   @doc "Associate a path with this request"
   @spec path(req :: Request.t(), Resource.t() | name) :: Request.t()
-  def path(%Request{} = req, %{type: _, id: _} = res),
-    do: %Request{req | base_url: get_url(resource(req, res))}
+  def path(%Request{} = req, %{type: _, id: _} = res) do
+    %Request{req | base_url: get_url(resource(req, res))}
+  end
 
-  def path(%Request{} = req, path),
-    do: %Request{req | path: String.trim(path, "/")}
+  def path(%Request{} = req, path) do
+    %Request{req | path: String.trim(path, "/")}
+  end
 
   @doc """
   Specify which fields to include

--- a/test/json_api_client/request_test.exs
+++ b/test/json_api_client/request_test.exs
@@ -1,7 +1,7 @@
 defmodule JsonApiClient.RequestTest do
   use ExUnit.Case
   doctest JsonApiClient.Request, import: true
-  alias JsonApiClient.Request
+  alias JsonApiClient.{Request, Resource}
   import JsonApiClient.Request
 
   describe "params()" do
@@ -232,6 +232,15 @@ defmodule JsonApiClient.RequestTest do
         |> path("/foo/bar/")
 
       assert "http://api.net/foo/bar" = get_url(req)
+    end
+
+    test "setting path by string will not infer url from resource" do
+      req =
+        new("http://api.net")
+        |> resource(%Resource{type: "article"})
+        |> path("/articles")
+
+      assert "http://api.net/articles" == get_url(req)
     end
   end
 

--- a/test/json_api_client/request_test.exs
+++ b/test/json_api_client/request_test.exs
@@ -83,7 +83,8 @@ defmodule JsonApiClient.RequestTest do
   end
 
   def assert_updates_param(field_name) do
-    assert %{params: %{^field_name => "someval"}} = apply(Request, field_name, [%Request{}, "someval"])
+    assert %{params: %{^field_name => "someval"}} =
+             apply(Request, field_name, [%Request{}, "someval"])
   end
 
   test "id", do: assert_updates_field(:id)
@@ -140,7 +141,11 @@ defmodule JsonApiClient.RequestTest do
     test "when request method is a post" do
       url =
         new("http://api.net")
-        |> resource(%JsonApiClient.Resource{type: "articles", id: "1", attributes: %{comment: "some_comment"}})
+        |> resource(%JsonApiClient.Resource{
+          type: "articles",
+          id: "1",
+          attributes: %{comment: "some_comment"}
+        })
         |> method(:post)
         |> get_url
 
@@ -170,7 +175,11 @@ defmodule JsonApiClient.RequestTest do
       url =
         new("http://api.net")
         |> path(%JsonApiClient.Resource{type: "notes", id: "123"})
-        |> resource(%JsonApiClient.Resource{type: "replies", id: "345", attributes: %{body: "body"}})
+        |> resource(%JsonApiClient.Resource{
+          type: "replies",
+          id: "345",
+          attributes: %{body: "body"}
+        })
         |> method(:post)
         |> get_url
 
@@ -190,7 +199,7 @@ defmodule JsonApiClient.RequestTest do
         new("http://api.net")
         |> path(%JsonApiClient.Resource{type: "articles"})
 
-      assert "http://api.net/articles" = req.base_url
+      assert "http://api.net/articles" = get_url(req)
     end
 
     test "when resource has id" do
@@ -198,7 +207,7 @@ defmodule JsonApiClient.RequestTest do
         new("http://api.net")
         |> path(%JsonApiClient.Resource{type: "articles", id: "1"})
 
-      assert "http://api.net/articles/1" = req.base_url
+      assert "http://api.net/articles/1" = get_url(req)
     end
 
     test "when path is a string" do
@@ -206,7 +215,7 @@ defmodule JsonApiClient.RequestTest do
         new("http://api.net")
         |> path("foo/bar")
 
-      assert "http://api.net/foo/bar" = req.base_url
+      assert "http://api.net/foo/bar" = get_url(req)
     end
 
     test "when path has a `/` at the beginning" do
@@ -214,7 +223,7 @@ defmodule JsonApiClient.RequestTest do
         new("http://api.net")
         |> path("/foo/bar")
 
-      assert "http://api.net/foo/bar" = req.base_url
+      assert "http://api.net/foo/bar" = get_url(req)
     end
 
     test "when path has a `/` at the and" do
@@ -222,7 +231,7 @@ defmodule JsonApiClient.RequestTest do
         new("http://api.net")
         |> path("/foo/bar/")
 
-      assert "http://api.net/foo/bar" = req.base_url
+      assert "http://api.net/foo/bar" = get_url(req)
     end
   end
 


### PR DESCRIPTION
#### What does this PR do?
adds a path field to the Request struct for storing a manually specified path with `Request.path/2`, changes that function to set the new field when handed a string instead of a Resource struct, and changes `Request.get_url/1` to use the path field if set, instead of automatically inferring the path from the Resource.

#### Why?
previously the path was being joined to the base_url field in the Request struct instead of being stored separately, which prevented `Request.get_url/1` from being able to discern if a path was manually specified or not (and thus whether it should try to infer the path from the Resource or not).

if there's a good reason i'm unaware of for storing a manually-specified path joined to the base_url, then i can take a different approach in implementing this functionality, but it seems to me that we'll have to indicate the presence of a manually-specified path in the struct one way or another, and this seemed to be the most straightforward approach.

#### What are the relevant tickets?
i could give you the number of an internal jira ticket from my day job that accounts for this work, but i suspect it'd be of little value to you. 😅 

#### PR Dependencies
no new dependencies added.

#### Other Questions:
- [y] Did I run this locally?
- [y] Did I run the whole test suite?
- [y] Did I add tests to cover the change?
- [y] Did I run dialyzer?
- [n] Any additional deploy/release considerations?
- [n] Does this PR cause necessary updates to the FAQ / documentation?

on the contrary, i believe it now makes some documentation examples work properly in a way that they previously would not have.

thanks for responding to my questions and reviewing my PR! i know firsthand that package maintenance can be a thankless and unstimulating task at times. please let me know if there's any changes or additions you'd like to see before merging and i'll do my best to oblige.