### PR TITLE
allow Resource typespec to have atom keys in relationships map

### DIFF
--- a/lib/json_api_client/document.ex
+++ b/lib/json_api_client/document.ex
@@ -108,7 +108,7 @@ defmodule JsonApiClient.Resource do
     type: any,
     attributes: map | nil,
     links: JsonApiClient.Links.t() | nil,
-    relationships: %{optional(String.t()) => JsonApiClient.Relationship.t()} | %{},
+    relationships: %{optional(String.t() | atom()) => JsonApiClient.Relationship.t()} | %{},
     meta: map | nil
   }
   defstruct(


### PR DESCRIPTION
#### What does this PR do?
hi it's me again! this one's a lot smaller, it just allows atom keys in the relationships map of the Resource typespec.

#### Why?
i noticed i was getting some dialyzer errors when using atom-keyed relationship maps in my code, even though it worked correctly, and tracked it down to this.

#### What are the relevant tickets?
none 😄 

#### PR Dependencies
also none!

#### Other Questions:
- [x] Did I run this locally?
- [x] Did I run the whole test suite?
- [ ] Did I add tests to cover the change?
- [x] Did I run dialyzer?
- [ ] Any additional deploy/release considerations?
- [ ] Does this PR cause necessary updates to the FAQ / documentation?
