### PR TITLE
Update types to fix #13

### DIFF
--- a/lib/json_api_client/document.ex
+++ b/lib/json_api_client/document.ex
@@ -83,6 +83,8 @@ defmodule JsonApiClient.ResourceIdentifier do
     meta: map | nil
   }
   defstruct id: nil, type: nil, meta: nil
+
+  @type t_or_list :: t() | [t()]
 end
 
 defmodule JsonApiClient.Relationship do
@@ -119,6 +121,8 @@ defmodule JsonApiClient.Resource do
     relationships: %{},
     meta: nil
   )
+
+  @type t_or_list :: t() | [t()]
 end
 
 defmodule JsonApiClient.JsonApi do
@@ -134,16 +138,19 @@ defmodule JsonApiClient.JsonApi do
 end
 
 defmodule JsonApiClient.Document do
+
+  @type data :: JsonApiClient.Resource.t_or_list() | JsonApiClient.ResourceIdentifier.t_or_list() | nil
+
   @moduledoc """
   JSON API Document Object
   http://jsonapi.org/format/#document-structure
   """
   @type t :: %__MODULE__{
     jsonapi: JsonApiClient.JsonApi.t(),
-    data: [JsonApiClient.ResourceIdentifier.t()] | JsonApiClient.ResourceIdentifier.t() | nil,
+    data: data(),
     links: JsonApiClient.Links.t() | nil,
     meta: map | nil,
-    included: [JsonApiClient.ResourceIdentifier.t()],
+    included: [JsonApiClient.Resource.t()] | [JsonApiClient.ResourceIdentifier.t()] | nil,
     errors: [JsonApiClient.Error.t()]
   }
   defstruct(

--- a/lib/json_api_client/request.ex
+++ b/lib/json_api_client/request.ex
@@ -4,6 +4,7 @@ defmodule JsonApiClient.Request do
   """
   alias __MODULE__
   alias JsonApiClient.Resource
+  alias JsonApiClient.Document
 
   @type http_methods ::
           :get | :post | :update | :delete | :put | :head | :options | :connect | :trace | :patch
@@ -12,7 +13,7 @@ defmodule JsonApiClient.Request do
           path: String.t() | nil,
           params: map | nil,
           id: binary | nil,
-          resource: Resource.t() | nil,
+          resource: Document.data(),
           method: http_methods,
           headers: map,
           options: map,
@@ -51,11 +52,11 @@ defmodule JsonApiClient.Request do
   def id(%Request{} = req, id), do: %Request{req | id: id}
 
   @doc "Specify the HTTP method for the request."
-  @spec method(req :: Request.t(), method :: atom) :: Request.t()
+  @spec method(req :: Request.t(), method :: http_methods) :: Request.t()
   def method(%Request{} = req, method), do: %Request{req | method: method}
 
   @doc "Associate a resource with this request"
-  @spec resource(req :: Request.t(), resource :: Resource.t()) :: Request.t()
+  @spec resource(req :: Request.t(), resource :: Document.data()) :: Request.t()
   def resource(%Request{} = req, resource), do: %Request{req | resource: resource}
 
   @doc "Associate a service_name with this request"
@@ -65,7 +66,7 @@ defmodule JsonApiClient.Request do
   end
 
   @doc "Associate a path with this request"
-  @spec path(req :: Request.t(), Resource.t() | name) :: Request.t()
+  @spec path(req :: Request.t(), Resource.t() | ResourceIdentifier.t() | name) :: Request.t()
   def path(%Request{} = req, %{type: _, id: _} = res) do
     %Request{req | base_url: get_url(resource(req, res))}
   end


### PR DESCRIPTION
#### What does this PR do?

This PR adjusts some type specs and function specs to fix issues running dialyzer with code that uses `JsonApiClient`.

All of these changes affect specs only, which means there are no functional changes. These changes fix issues using dialyzer in my project.

* `%JsonApiClient.Document{data: }` now accepts `Resource.t() | [Resource.t()] | ResourceIdentifier.t() | [ResourceIdentifier.t()] | nil`, where before it would not accept the `Resource` case

  This allows writing a function that expects to parse a list of resources from a document response.

* A new type `JsonApiClient.Document.data()`, is a shortcut for `Resource.t() | [Resource.t()] | ResourceIdentifier.t() | [ResourceIdentifier.t()] | nil`

* `%JsonApiClient.Document{included: }` now accepts both `[ResourceIdentifier.t()]` and `[Resource.t()]`, where before it only accepted the `ResourceIdentifier` case

* `JsonApiClient.Request.resource/2` now accepts any of the options for the new `JsonApiClient.Document.data()` type

  This allows adding a list of resources or a list of resource identifiers to a request, where this was impossible before (with dialyzer checks).

  Also, the type for `%JsonApiClilent.Request{resource: }` is updated to accommodate this change.

* `JsonApiClient.Request.method/2` is updated to only take `http_method`s, where before it would only accept any `atom`

  I had a bug in my code where I used the method `:POST` instead of `:post`. JsonApiClient only adds the `resource` to the request if the method is a lowercase atom (like `:post`). This changes causes dialyzer to fail for my buggy code.

* `JsonApiClient.Request.path/2` can take a `ResourceIdentifier.t()` as well as a `Resource.t()` since all it needs is the `type` and `id`

#### Why?

Some type specs and function specs were too restrictive, where using `JsonApiClient` in a way that was supported would fail dialyzer checks. Another was not restrictive enough (`JsonApiClient.Request.method`), allowing incorrect code to pass dialyzer checks. These changes should help dialyzer prevent issues with client code.

#### What are the relevant tickets?

This resolves #13 

#### Other Questions:
- [x] Did I run this locally?
- [x] Did I run the whole test suite?

  Green for me.

- [ ] Did I add tests to cover the change?

  There are no functional changes, so I don't think there are any tests to write.

- [x] Did I run dialyzer?

  Yes, and I ran dialyzer in my project against these changes and they resolved my issues.

- [ ] Any additional deploy/release considerations?

  Not that I know of. Is there anything to be done to release this to hex? What about hexdocs?

- [ ] Does this PR cause necessary updates to the FAQ / documentation?

  I'm assuming hexdocs will pick up the changes automatically. Otherwise, I don't know; is there anything else I need to change?
